### PR TITLE
Update URL to the Editor's Draft

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -7,7 +7,7 @@ Level: 1
 Editor: Ian Clelland, Google https://google.com, iclelland@chromium.org, w3cid 76841
         Tim Dresser, Google https://google.com, tdresser@chromium.org
 Former Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org
-URL: https://wicg.github.io/element-timing
+URL: https://w3c.github.io/element-timing/
 Repository: https://github.com/w3c/element-timing
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/element-timing
 Abstract: This document defines an API that enables monitoring when large or developer-specified image elements and text nodes are displayed on screen.


### PR DESCRIPTION
The "This version" link still pointed at the WICG URL.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/element-timing/pull/85.html" title="Last updated on Jan 9, 2025, 3:24 PM UTC (16ad29b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/element-timing/85/9b02531...tidoust:16ad29b.html" title="Last updated on Jan 9, 2025, 3:24 PM UTC (16ad29b)">Diff</a>