### PR TITLE
Fix typo "o a 4 second"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -269,7 +269,7 @@ We choose to expose the {{loadTime}} because it is very easy to obtain even with
 In addition, we believe any fix to remove the leak provided by image onload handlers or ResourceTiming could also fix the leak provided by this API.
 
 The {{renderTime}} (display timestamp) is indeed newly exposed information. Implementations are advised to coarsen that timestamp further,
-o a 4 milliseconds resolution at least, to avoid exposing differences in decoding time between cross-origin images. Note that other checks,
+to a 4 milliseconds resolution at least, to avoid exposing differences in decoding time between cross-origin images. Note that other checks,
 such as `Timing-Allow-Origin`, does not work here due to same-origin and cross-origin images being rendered at the same time.
 Exposing a coarse {{renderTime}} is anyway not a substantial attack vector, given that image [=natural size=] and loading time are exposed in other ways.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bkardell/element-timing/pull/86.html" title="Last updated on Apr 28, 2025, 6:47 PM UTC (b4e80a3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/element-timing/86/6180e4d...bkardell:b4e80a3.html" title="Last updated on Apr 28, 2025, 6:47 PM UTC (b4e80a3)">Diff</a>