### PR TITLE
Use new [Reflect] instead of spec prose

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -196,11 +196,9 @@ We extend the {{Element}} interface as follows:
 
 <pre class="idl">
 partial interface Element {
-    [CEReactions] attribute DOMString elementTiming;
+    [CEReactions, Reflect] attribute DOMString elementTiming;
 };
 </pre>
-
-The {{Element/elementTiming}} attribute must <a>reflect</a> the element's "<code>elementtiming</code>" content attribute.
 
 Report Element Timing {#sec-report-element-timing}
 --------------------------------------------------


### PR DESCRIPTION
We recently standardised the [Reflect] IDL extended attribute into the HTML spec, so this PR updates this spec to use that instead of spec prose for element timing reflection.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/lukewarlow/element-timing/pull/88.html" title="Last updated on Aug 4, 2025, 4:04 PM UTC (c0b2ea1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/element-timing/88/be855c7...lukewarlow:c0b2ea1.html" title="Last updated on Aug 4, 2025, 4:04 PM UTC (c0b2ea1)">Diff</a>